### PR TITLE
fix duplicate source inclusion

### DIFF
--- a/src/sdl.zon
+++ b/src/sdl.zon
@@ -473,7 +473,6 @@
         "camera/coremedia/SDL_camera_coremedia.m",
         "render/metal/SDL_render_metal.m",
         "gpu/metal/SDL_gpu_metal.m",
-        "joystick/darwin/SDL_iokitjoystick.c",
         "joystick/apple/SDL_mfijoystick.m",
     },
     .emscripten = .{

--- a/src/sdl.zon
+++ b/src/sdl.zon
@@ -109,6 +109,7 @@
         "io/SDL_asyncio.c",
         "io/SDL_iostream.c",
         "joystick/controller_type.c",
+        "joystick/darwin/SDL_iokitjoystick.c",
         "joystick/dummy/SDL_sysjoystick.c",
         "joystick/gdk/SDL_gameinputjoystick.cpp",
         "joystick/hidapi/SDL_hidapi_8bitdo.c",
@@ -473,7 +474,6 @@
         "render/metal/SDL_render_metal.m",
         "gpu/metal/SDL_gpu_metal.m",
         "joystick/apple/SDL_mfijoystick.m",
-        "joystick/darwin/SDL_iokitjoystick.c",
     },
     .emscripten = .{
         "filesystem/emscripten/SDL_sysfilesystem.c",

--- a/src/sdl.zon
+++ b/src/sdl.zon
@@ -109,7 +109,6 @@
         "io/SDL_asyncio.c",
         "io/SDL_iostream.c",
         "joystick/controller_type.c",
-        "joystick/darwin/SDL_iokitjoystick.c",
         "joystick/dummy/SDL_sysjoystick.c",
         "joystick/gdk/SDL_gameinputjoystick.cpp",
         "joystick/hidapi/SDL_hidapi_8bitdo.c",
@@ -474,6 +473,7 @@
         "render/metal/SDL_render_metal.m",
         "gpu/metal/SDL_gpu_metal.m",
         "joystick/apple/SDL_mfijoystick.m",
+        "joystick/darwin/SDL_iokitjoystick.c",
     },
     .emscripten = .{
         "filesystem/emscripten/SDL_sysfilesystem.c",


### PR DESCRIPTION
`SDL_iokitjoystick.c` is included in both the generic and cocoa source list. This can cause issues on Mac, especially with [zig-compile-commands](https://github.com/the-argus/zig-compile-commands).